### PR TITLE
Update tutorial theme to Timber 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Learn Timber Theme
 
-Head over to the [Introduction](https://timber.github.io/docs/getting-started/introduction/) in Timber’s Getting Started section to learn more about how to use this.
+Head over to the [Introduction](https://timber.github.io/docs/v2/getting-started/introduction/) in Timber’s Getting Started section to learn more about how to use this.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "wordpress-theme",
   "description": "A minimal theme that serves as an entry point for learning about Timber.",
   "require": {
-    "timber/timber": "^1.16"
+    "timber/timber": "^2.0"
   },
   "authors": [
     {

--- a/functions.php
+++ b/functions.php
@@ -4,4 +4,4 @@ use Timber\Timber;
  
 require_once __DIR__ . '/vendor/autoload.php';
 
-new Timber();
+Timber::init();


### PR DESCRIPTION
Hi @gchtr ,

The[ tutorial theme](https://timber.github.io/docs/v2/getting-started/introduction/) is still for Timber 1.x, let's fix that.

- [x] Make code changes
- [x] Publish to packagist